### PR TITLE
Fix isWin test in LivestreamerController.js

### DIFF
--- a/src/app/controllers/LivestreamerController.js
+++ b/src/app/controllers/LivestreamerController.js
@@ -1,7 +1,7 @@
 define( [ "ember" ], function( Ember ) {
 
 	var	FS		= require( "fs" ),
-		isWin	= /^win$/.test( process.platform ),
+		isWin	= /^win/.test( process.platform ),
 		PATH	= process.env.PATH || process.env.Path || process.env.path || ".",
 		PATHS	= PATH.split( isWin ? ";" : ":" ),
 		EXTS	= [ ".exe" ]; // isWin ? process.env.PATHEXT.split( ";" ) : null;


### PR DESCRIPTION
process.platform on os x is "darwin" which matches the /win/ regex
