### PR TITLE
Update to non-legacy chat url

### DIFF
--- a/src/config/twitch.json
+++ b/src/config/twitch.json
@@ -1,6 +1,6 @@
 {
 	"stream-url": "twitch.tv/{channel}",
-	"chat-url": "https://www.twitch.tv/{channel}/chat",
+	"chat-url": "https://www.twitch.tv/popout/{channel}/chat",
 	"emotes-url": "https://twitchemotes.com/channel/{channel}",
 	"subscription": {
 		"create-url": "https://www.twitch.tv/{channel}/subscribe",


### PR DESCRIPTION
Twitch recently moved the current chat URL to legacy. Updated the chat URL.