### PR TITLE
AppImage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,13 @@ trim_trailing_whitespace = true
 indent_size = 4
 insert_final_newline = false
 
+# xml files
+[**.xml]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
 # markdown files
 [**.md]
 trim_trailing_whitespace = false

--- a/.github/workflows/build-squashfs-tools.sh
+++ b/.github/workflows/build-squashfs-tools.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+[[ "${CI}" ]] || exit 1
+
+tempdir=$(mktemp -d) && trap "rm -rf ${tempdir}" EXIT || exit 255
+cd "${tempdir}"
+
+COMMIT="c570c6188811088b12ffdd9665487a2960c997a0"
+CHECKSUM="3d9721507fd3ab53e5831f2a2076e8801fb33c2e2cfa86a5ab4dcb3720375e0c"
+
+curl -SL -o squashfs-tools.tar.gz "https://github.com/plougher/squashfs-tools/archive/${COMMIT}.tar.gz"
+echo "${CHECKSUM}  squashfs-tools.tar.gz" | sha256sum -c
+
+tar -xzvf squashfs-tools.tar.gz
+cd "./squashfs-tools-${COMMIT}/squashfs-tools/"
+
+set -x
+
+sudo apt install make libattr1-dev zlib1g-dev
+make \
+  GZIP_SUPPORT=1 \
+  XZ_SUPPORT=0 \
+  LZO_SUPPORT=0 \
+  LZMA_XZ_SUPPORT=0 \
+  LZ4_SUPPORT=0 \
+  ZSTD_SUPPORT=0 \
+  XATTR_SUPPORT=1
+sudo make install \
+  INSTALL_DIR=/usr/local/bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install dependencies
         run: |
           yarn install --pure-lockfile --no-progress --non-interactive
-          sudo apt install nsis
+          sudo apt install nsis appstream{,-util}
           ./.github/workflows/install-wine.sh
       - name: Build
         run: yarn run grunt clean:tmp_prod webpack:prod

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,7 @@ jobs:
           yarn install --pure-lockfile --no-progress --non-interactive
           sudo apt install nsis appstream{,-util}
           ./.github/workflows/install-wine.sh
+          ./.github/workflows/build-squashfs-tools.sh
       - name: Build
         run: yarn run grunt clean:tmp_prod webpack:prod
       - name: Compile & package

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,7 @@ module.exports = function( grunt ) {
 				tmp_test: r( "build", "tmp", "test" ),
 				tmp_coverage: r( "build", "tmp", "coverage" ),
 				tmp_installer: r( "build", "tmp", "installer" ),
+				tmp_appimage: r( "build", "tmp", "appimage" ),
 				dist: r( "dist" )
 			}
 		},

--- a/build/resources/appimage/build.sh.tpl
+++ b/build/resources/appimage/build.sh.tpl
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -e
+
+
+name="<%= name %>"
+version="<%= version %>"
+arch="<%= arch %>"
+source="<%= dirinput %>"
+dest="<%= diroutput %>/<%= filename %>"
+apprun="<%= appimagekit %>/<%= apprun %>"
+appimagetool="<%= appimagekit %>/<%= appimagetool %>"
+
+# ----
+
+tempdir=$(mktemp -d) && trap "rm -rf ${tempdir}" EXIT || exit 255
+cd "${tempdir}"
+
+appdir="${tempdir}/${name}.AppDir"
+installdir="${appdir}/opt/${name}/"
+
+# ----
+
+# create AppImage AppDir
+mkdir "${appdir}"
+
+# copy root AppRun
+install -m777 "${apprun}" "${appdir}/AppRun"
+
+# copy app contents
+mkdir -p "${installdir}"
+cp -a "${source}/." "${installdir}/"
+
+# create custom start script and unset PYTHONHOME env var
+mkdir -p "${appdir}/usr/bin/"
+cat > "${appdir}/usr/bin/${name}" <<EOF
+#!/usr/bin/env bash
+SELF=\$(readlink -f "\$0")
+HERE=\${SELF%/*}
+
+unset PYTHONHOME
+"\${HERE}"/../../opt/${name}/${name} "\$@"
+EOF
+chmod +x "${appdir}/usr/bin/${name}"
+
+# copy licenses
+install -Dm644 \
+  -t "${appdir}/usr/share/licenses/${name}/" \
+  "${installdir}/LICENSE.txt" \
+  "${installdir}/credits.html"
+
+# copy icons
+for res in 16 32 48 64 128 256; do
+  install -Dm644 \
+    "${installdir}/icons/icon-${res}.png" \
+    "${appdir}/usr/share/icons/hicolor/${res}x${res}/apps/${name}.png"
+done
+
+# symlink root AppImage icons
+for link in "${appdir}/.DirIcon" "${appdir}/${name}.png"; do
+  ln -sr "${appdir}/usr/share/icons/hicolor/256x256/apps/${name}.png" "${link}"
+done
+
+# create desktop file
+mkdir -p "${appdir}/usr/share/applications/"
+cat > "${appdir}/usr/share/applications/${name}.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Streamlink Twitch GUI
+GenericName=Twitch.tv browser for Streamlink
+Comment=Browse Twitch.tv and watch streams in your videoplayer of choice
+Keywords=streamlink;twitch;
+Categories=AudioVideo;Network;
+Exec=${name}
+Icon=${name}
+EOF
+
+# symlink root AppImage desktop file
+ln -sr "${appdir}/usr/share/applications/${name}.desktop" "${appdir}/${name}.desktop"
+
+# remove unneeded stuff
+rm -r "${installdir}/"{{add,remove}-menuitem.sh,LICENSE.txt,credits.html,icons/}
+
+# ----
+
+# build AppImage
+(
+  set -x
+  ARCH="${arch}" VERSION="${version}" "${appimagetool}" \
+    --verbose \
+    --comp gzip \
+    --no-appstream \
+    "${appdir}" \
+    "${dest}"
+)
+chmod +x "${dest}"

--- a/build/resources/linux/streamlink-twitch-gui.appdata.xml
+++ b/build/resources/linux/streamlink-twitch-gui.appdata.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <name>Streamlink Twitch GUI</name>
+  <id>io.github.streamlink.gui.twitch</id>
+  <summary>Browse Twitch.tv and watch streams in your videoplayer of choice</summary>
+  <description>
+    <p>
+      A graphical user interface on top of the Streamlink command line interface.
+    </p>
+    <p>
+      Streamlink Twitch GUI is a NW.js application, which means that it is a web application
+      written in JavaScript (EmberJS), HTML (Handlebars) and CSS (LessCSS) and is being run
+      by a Node.js powered version of Chromium.
+    </p>
+  </description>
+  <developer_name>Sebastian Meyer</developer_name>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <url type="homepage">https://streamlink.github.io/streamlink-twitch-gui/</url>
+  <url type="bugtracker">https://github.com/streamlink/streamlink-twitch-gui/issues</url>
+  <url type="help">https://github.com/streamlink/streamlink-twitch-gui/wiki</url>
+  <url type="translate">https://github.com/streamlink/streamlink-twitch-gui/wiki/Translating</url>
+  <provides>
+    <binary>streamlink-twitch-gui</binary>
+  </provides>
+  <launchable type="desktop-id">streamlink-twitch-gui.desktop</launchable>
+  <categories>
+    <category>AudioVideo</category>
+    <category>Network</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="1920" height="1080">https://user-images.githubusercontent.com/467294/32060296-a08d7b44-ba6e-11e7-9793-8ef60fc3e1f0.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="960" height="540">https://user-images.githubusercontent.com/467294/28097571-3415adda-66b1-11e7-86dd-6aac8f41f91f.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="960" height="540">https://user-images.githubusercontent.com/467294/28097572-3415f4a2-66b1-11e7-9eeb-20b21b2ac6a7.jpg</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/build/tasks/common/github-api.js
+++ b/build/tasks/common/github-api.js
@@ -1,0 +1,40 @@
+const fetch = require( "node-fetch" );
+
+
+const defaultRepo = process.env[ "GITHUB_REPOSITORY" ] || require( "../../../package.json" ).name;
+
+
+/**
+ * @param {string?} repo
+ * @param {string?} apikey
+ * @return {function(string, RequestInit=, string=): *}
+ */
+function githubApi( repo = defaultRepo, apikey = "" ) {
+	const headers = {
+		"Accept": "application/vnd.github.v3+json",
+		"User-Agent": repo
+	};
+	if ( apikey ) {
+		headers[ "Authorization" ] = `token ${apikey}`;
+	}
+
+	/**
+	 * @param {string} path
+	 * @param {RequestInit?} req
+	 * @param {string="api"} host
+	 * @returns {Promise<Object>}
+	 */
+	async function githubApiCall( path, req = {}, host = "api" ) {
+		const url = `https://${host}.github.com${path}`;
+		req.headers = Object.assign( req.headers || {}, headers );
+
+		const resp = await fetch( url, req );
+
+		return await resp.json();
+	}
+
+	return githubApiCall;
+}
+
+
+module.exports = githubApi;

--- a/build/tasks/common/hash.js
+++ b/build/tasks/common/hash.js
@@ -1,0 +1,18 @@
+const { createHash } = require( "crypto" );
+const { createReadStream } = require( "fs" );
+
+
+module.exports = async function hash( file, algorithm = "sha256", encoding = "hex" ) {
+	return new Promise( ( resolve, reject ) => {
+		const hash = createHash( algorithm );
+		hash.setEncoding( encoding );
+
+		const stream = createReadStream( file );
+		stream.on( "error", reject );
+		stream.on( "end", () => {
+			hash.end();
+			resolve( hash.read() );
+		});
+		stream.pipe( hash );
+	});
+};

--- a/build/tasks/configs/appimagekit.js
+++ b/build/tasks/configs/appimagekit.js
@@ -1,0 +1,25 @@
+module.exports = {
+	options: {
+		source: "AppImage/AppImageKit",
+		version: "12",
+		path: "<%= dir.tmp_appimage %>/<%= appimagekit.options.version %>",
+		files: {
+			"appimagetool-x86_64.AppImage":
+				"d918b4df547b388ef253f3c9e7f6529ca81a885395c31f619d9aaf7030499a13",
+			"AppRun-x86_64":
+				"e8f44f56bb23e105905850250d9d87fb1a5cf64211ad141b85864b1b7a092332",
+			"appimagetool-i686.AppImage":
+				"3af6839ab6d236cd62ace9fbc2f86487f0bf104f521d82da6dea4dab8d3ce4ca",
+			"AppRun-i686":
+				"9b7933e96ed4ad8b4275fd105c9921d95a388519369dcd5ec1249a72cd5c8c85"
+		},
+		apprun: {
+			linux32: "AppRun-i686",
+			linux64: "AppRun-x86_64"
+		},
+		appimagetool: {
+			linux32: "appimagetool-i686.AppImage",
+			linux64: "appimagetool-x86_64.AppImage"
+		}
+	}
+};

--- a/build/tasks/configs/clean.js
+++ b/build/tasks/configs/clean.js
@@ -29,6 +29,10 @@ module.exports = {
 		"<%= dir.tmp_coverage %>/**",
 		"!<%= dir.tmp_coverage %>"
 	],
+	tmp_appimage: [
+		"<%= dir.tmp_appimage %>/**",
+		"!<%= dir.tmp_appimage %>"
+	],
 
 	cache: [
 		"<%= dir.cache %>/**",

--- a/build/tasks/configs/compile.js
+++ b/build/tasks/configs/compile.js
@@ -19,6 +19,7 @@ module.exports = {
 		after : [
 			"copy:scripts_linux32",
 			"copy:icons_linux32",
+			"copy:assets_linux32",
 			"shell:permissions_linux32"
 		]
 	},
@@ -27,6 +28,7 @@ module.exports = {
 		after : [
 			"copy:scripts_linux64",
 			"copy:icons_linux64",
+			"copy:assets_linux64",
 			"shell:permissions_linux64"
 		]
 	}

--- a/build/tasks/configs/copy.js
+++ b/build/tasks/configs/copy.js
@@ -37,5 +37,18 @@ module.exports = {
 		flatten: true,
 		src    : "<%= dir.resources %>/icons/*.png",
 		dest   : "<%= dir.releases %>/<%= package.name %>/linux64/icons/"
+	},
+
+	assets_linux32: {
+		expand : true,
+		flatten: true,
+		src    : "<%= dir.resources %>/linux/*.!(sh)",
+		dest   : "<%= dir.releases %>/<%= package.name %>/linux32/"
+	},
+	assets_linux64: {
+		expand : true,
+		flatten: true,
+		src    : "<%= dir.resources %>/linux/*.!(sh)",
+		dest   : "<%= dir.releases %>/<%= package.name %>/linux64/"
 	}
 };

--- a/build/tasks/configs/deploy.js
+++ b/build/tasks/configs/deploy.js
@@ -17,6 +17,6 @@ module.exports = {
 				donation: "<%= JSON.stringify( main['donation'] ) %>"
 			}
 		},
-		src: "<%= dir.dist %>/*{.tar.gz,.zip,.exe,-checksums.txt}"
+		src: "<%= dir.dist %>/*{.tar.gz,.zip,.exe,.AppImage,-checksums.txt}"
 	}
 };

--- a/build/tasks/configs/dist.js
+++ b/build/tasks/configs/dist.js
@@ -42,5 +42,24 @@ module.exports = {
 			"shell:installer_win64"
 		],
 		checksum: "<%= dir.dist %>/<%= template.installer_win64.options.data.filename %>"
+	},
+
+	appimage_linux32: {
+		platform: "linux32",
+		tasks: [
+			"appimagekit",
+			"template:appimage_linux32",
+			"shell:appimage_linux32"
+		],
+		checksum: "<%= dir.dist %>/<%= template.appimage_linux32.options.data.filename %>"
+	},
+	appimage_linux64: {
+		platform: "linux64",
+		tasks: [
+			"appimagekit",
+			"template:appimage_linux64",
+			"shell:appimage_linux64"
+		],
+		checksum: "<%= dir.dist %>/<%= template.appimage_linux64.options.data.filename %>"
 	}
 };

--- a/build/tasks/configs/shell.js
+++ b/build/tasks/configs/shell.js
@@ -44,5 +44,12 @@ module.exports = {
 			"mkdir -p \"<%= dir.tmp_installer %>\"",
 			"makensis -v3 \"<%= dir.tmp_installer %>/win64installer/installer.nsi\""
 		].join( " && " )
+	},
+
+	appimage_linux32: {
+		command: "bash '<%= dir.tmp_appimage %>/build-linux32.sh'"
+	},
+	appimage_linux64: {
+		command: "bash '<%= dir.tmp_appimage %>/build-linux64.sh'"
 	}
 };

--- a/build/tasks/configs/template.js
+++ b/build/tasks/configs/template.js
@@ -69,5 +69,44 @@ module.exports = {
 			"<%= dir.tmp_installer %>/win64installer/installer.nsi":
 				"<%= dir.resources %>/installer/installer.nsi"
 		}
+	},
+
+	appimage_linux32: {
+		options: {
+			data: {
+				dirinput: "<%= dir.releases %>/<%= package.name %>/linux32",
+				diroutput: "<%= dir.dist %>",
+				filename: "<%= package.name %>-v<%= package.version %>-i686.AppImage",
+				name: "<%= package.name %>",
+				version: "<%= package.version %>",
+				appimagekit: "<%= appimagekit.options.path %>",
+				apprun: "<%= appimagekit.options.apprun.linux32 %>",
+				appimagetool: "<%= appimagekit.options.appimagetool.linux32 %>",
+				arch: "i686"
+			}
+		},
+		files: {
+			"<%= dir.tmp_appimage %>/build-linux32.sh":
+				"<%= dir.resources %>/appimage/build.sh.tpl"
+		}
+	},
+	appimage_linux64: {
+		options: {
+			data: {
+				dirinput: "<%= dir.releases %>/<%= package.name %>/linux64",
+				diroutput: "<%= dir.dist %>",
+				filename: "<%= package.name %>-v<%= package.version %>-x86_64.AppImage",
+				name: "<%= package.name %>",
+				version: "<%= package.version %>",
+				appimagekit: "<%= appimagekit.options.path %>",
+				apprun: "<%= appimagekit.options.apprun.linux64 %>",
+				appimagetool: "<%= appimagekit.options.appimagetool.linux64 %>",
+				arch: "x86_64"
+			}
+		},
+		files: {
+			"<%= dir.tmp_appimage %>/build-linux64.sh":
+				"<%= dir.resources %>/appimage/build.sh.tpl"
+		}
 	}
 };

--- a/build/tasks/custom/appimagekit.js
+++ b/build/tasks/custom/appimagekit.js
@@ -1,0 +1,68 @@
+const hash = require( "../common/hash" );
+const githubApi = require( "../common/github-api" );
+const fetch = require( "node-fetch" );
+const { createWriteStream, promises: { mkdir, stat } } = require( "fs" );
+const { resolve: r } = require( "path" );
+
+
+module.exports = function( grunt ) {
+	async function appImageKit() {
+		const { source, version, path, files } = this.options();
+
+		// create directory
+		await mkdir( path, { recursive: true } );
+
+		// check which files are missing
+		const missing = [];
+		for ( const file of Object.keys( files ) ) {
+			try {
+				await stat( r( path, file ) );
+			} catch {
+				missing.push( file );
+			}
+		}
+
+		// download missing files
+		if ( missing.length ) {
+			const githubApiCall = githubApi();
+			const { assets } = await githubApiCall( `/repos/${source}/releases/tags/${version}` );
+			if ( !Array.isArray( assets ) ) {
+				throw new Error( "Invalid Github API response" );
+			}
+
+			const downloads = assets
+				.filter( ({ name }) => missing.includes( name ) )
+				.map( ({ name, browser_download_url }) => fetch( browser_download_url )
+					.then( resp => new Promise( ( resolve, reject ) => {
+						grunt.log.writeln( `Downloading: ${name}` );
+						const stream = createWriteStream( r( path, name ), {
+							mode: 0o777
+						});
+						stream.on( "error", reject );
+						stream.on( "finish", resolve );
+						resp.body.pipe( stream );
+					}) )
+					.then( () => grunt.log.ok( `Successfully downloaded: ${name}` ) )
+				);
+
+			await Promise.all( downloads );
+		}
+
+		// finally compare checksums and validate
+		for ( const [ file, checksum ] of Object.entries( files ) ) {
+			const data = await hash( r( path, file ) );
+			if ( data !== checksum ) {
+				throw new Error( `Invalid checksum for: ${file}` );
+			}
+		}
+
+		grunt.log.ok( "All files successfully validated" );
+	}
+
+	grunt.registerTask( "appimagekit", function() {
+		const done = this.async();
+
+		appImageKit.call( this )
+			.then( done, grunt.fail.fatal );
+	});
+};

--- a/build/tasks/custom/checksum.js
+++ b/build/tasks/custom/checksum.js
@@ -1,7 +1,7 @@
 const platforms = require( "../common/platforms" );
+const hash = require( "../common/hash" );
 const config = require( "../configs/dist" );
-const { createHash } = require( "crypto" );
-const { createReadStream, writeFile } = require( "fs" );
+const { writeFile } = require( "fs" );
 const { resolve: r, basename, relative } = require( "path" );
 
 
@@ -30,21 +30,12 @@ module.exports = function( grunt ) {
 		const promises = targets
 			.map( target => grunt.config.process( config[ target ].checksum ) )
 			.sort()
-			.map( file => new Promise( ( resolve, reject ) => {
-				const hash = createHash( options.algorithm );
-				hash.setEncoding( options.encoding );
-
-				const stream = createReadStream( file );
-				stream.on( "error", reject );
-				stream.on( "end", () => {
-					hash.end();
-					resolve({
-						file: basename( file ),
-						hash: hash.read()
-					});
-				});
-				stream.pipe( hash );
-			}) );
+			.map( file => hash( file, options.algorithm, options.encoding )
+				.then( hash => ({
+					file: basename( file ),
+					hash
+				}) )
+			);
 
 		Promise.all( promises )
 			.then( list => list

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"loader-utils": "1.1.0",
 		"lodash": "4.17.11",
 		"mini-css-extract-plugin": "0.4.0",
+		"node-fetch": "3.0.0-beta.7",
 		"nw-builder": "3.5.7",
 		"optimize-css-assets-webpack-plugin": "5.0.3",
 		"qunit": "2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,6 +3852,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
+  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -5096,6 +5101,11 @@ fd-slicer@~1.1.0:
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
+
+fetch-blob@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-2.0.1.tgz#64b583cd2bd21685b17706818b388af08cb40b9b"
+  integrity sha512-1jFpa68M4EzObtFa7XOKZoN1unsaeJ6hGSbxaWaVO+TkHmVvnyzRu1ktZAFbUvTZ9NC/qMKGKJ79dK4MzuSBiw==
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -7529,6 +7539,14 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
+
+node-fetch@3.0.0-beta.7:
+  version "3.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.0.0-beta.7.tgz#28e122943aa8a3e4e7447d525fc138c207faa834"
+  integrity sha512-UTmmxR2RCLiGL0q61p8DgMgw1UXd10+XVB77IHG55flJ/tHqQQXloNTm5dd/mB3RNXP3+CJPf++t0nb3whKNkw==
+  dependencies:
+    data-uri-to-buffer "^3.0.1"
+    fetch-blob "^2.0.0"
 
 node-fetch@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Build AppImage release files
https://appimage.org/

Resolves #616

- [x] Refactor `checksum` and `deploy:github` grunt tasks
  - Add `node-fetch` to the devDependencies
- [x] Add `appimagekit` grunt task that downloads/caches AppImageKit release files (version 12)
  https://github.com/AppImage/AppImageKit
- [x] Build AppImages
  - [x] Add build script template for `i686` and `x86_64` builds
  - [x] Properly build AppDir
    - app contents
    - launch script
    - icons
    - licenses
    - metainfo
    - root AppRun file
    - root .desktop file
    - root .DirIcon and main app icon
  - [x] Unset `PYTHON_HOME` env var
    This is necessary for making Streamlink work from the AppImage. AppImageKit's AppRun file sets this env var and thus breaks all Python modules outside the AppImage. There's an alternative AppRun script in the git repo, which doesn't set the env var, but it's not being used here. I'm not sure if unsetting the `PYTHON_HOME` env var might break some user's configuration. If that's the case, then this needs to be fixed here.
  - [x] Reproducible builds
    Unfortunately, AppImageKit version 12 comes with an embedded squashfs-tools build older than 4.4 and doesn't support reproducible builds. It therefore needs to be replaced with the system's binary. Since Ubuntu 18.04 (ubuntu-latest on Github Actions) is stuck on an older build as well, squashfs-tools needs to be build on the CI side as well.
  - [x] Add AppStream metainfo
    This also adds the `streamlink-twitch-gui.metainfo.xml` file to the archive release files.
    Not sure about the `id` field, which is currently set to `io.github.streamlink.gui.twitch`. This app identifier has not been used before, but it is required when following the spec strictly. Lots of applications don't seem to follow the AppStream specification stricly (eg. Chromium on Arch), which is quite confusing. Half of the metainfo/appinfo files are invalid and the `appstreamcli` and `appstream-util` linting/verification tools are both reporting different results.
    The AppImageKit version also requires to verify the metainfo file with the system tools, as using the embedded ones doesn't work. The exact commands have been taken from the `appstreamtool.c` file.
- [x] Update CI and deploy config
- [x] Create a test release on the test repo / test account
- [x] Test AppImage
  - [x] `i686`
  - [x] `x86_64`
- [x] Test AppImage with AppImageLauncher and its system integration
- [ ] Add AppImage update information
  Can be done later. This would also require zsync metadata to be added to the releases.
- [ ] Sign AppImages
  Can be done later. Releases haven't been signed yet and a pub-key hasn't been published yet, because
  - Windows users simply don't care, which are the majority of users
  - macOS users only have the homebrew package and probably don't care either
  - apart from the packages on the AUR and on Solus, there are no packages available
  - there are already 8 github release assets (plus 2 additional AppImage assets in the future), which would all have to be signed and would thus clutter up the release assets list. Signing just the checksums would probably be enough, but I'm not sure if this is good enough for the existing packages.