### PR TITLE
Upload scheduled debug builds to Github actions artifacts

### DIFF
--- a/.github/workflows/check-previous-run.sh
+++ b/.github/workflows/check-previous-run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+[[ "${CI}" ]] || exit 1
+
+HOST="https://api.github.com"
+HEADERS=(
+  -H "Accept: application/vnd.github.v3+json"
+  -H "User-Agent: ${GITHUB_REPOSITORY}"
+)
+URL="${HOST}/repos/${GITHUB_REPOSITORY}/actions/runs?branch=${GITHUB_REF#refs/heads/}&event=${GITHUB_EVENT_NAME}&status=success&per_page=1"
+SELECT=".workflow_runs[].head_sha | select(. == \"${GITHUB_SHA}\")"
+
+success() {
+  echo "$@"
+  exit 0
+}
+
+cancel() {
+  echo "$@"
+  curl -sSL \
+    -X POST \
+    "${HEADERS[@]}" \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    "${HOST}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel"
+  sleep 60
+  exit 1
+}
+
+MAX=5
+SLEEP=5
+for n in $(seq 1 ${MAX}); do
+  echo "Checking GitHub API for previous run... (${n}/${MAX})"
+  data="$(curl -sSL "${HEADERS[@]}" "${URL}")"
+  [[ $? > 0 ]] && sleep "${SLEEP}" && continue
+  if jq -re "${SELECT}" <<< "${data}" >/dev/null 2>/dev/null; then
+    cancel "Previous run found, aborting..."
+  else
+    success "Previous run not found, continuing..."
+  fi
+done
+
+cancel "Could not query GitHub API, aborting..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: Test, build and deploy
 on:
   push: {}
   pull_request: {}
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   CI: true
@@ -65,6 +67,60 @@ jobs:
         with:
           name: os:${{ matrix.os }}
           file: build/tmp/coverage/coverage.json
+
+  debug-build:
+    name: Debug build
+    if: github.repository == 'streamlink/streamlink-twitch-gui' && github.event_name == 'schedule'
+    needs:
+      - test
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check previous run
+        run: ./.github/workflows/check-previous-run.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Prepare env vars
+        run: |
+          echo ::set-env name=SOURCE_DATE_EPOCH::$(git show -s --format=%ct "${GITHUB_REF}")
+      - name: Install dependencies
+        run: |
+          yarn install --pure-lockfile --no-progress --non-interactive
+          sudo apt install pigz
+          ./.github/workflows/install-wine.sh
+      - name: Build
+        run: yarn run grunt clean:tmp_debug webpack:debug
+      - name: Compile & package
+        run: yarn run grunt clean:dist dist:archive_win64:archive_osx64:archive_linux64:debug
+      - name: Get file names for artifact upload
+        id: names
+        run: |
+          echo ::set-output name=archive_win64::$(basename dist/streamlink-twitch-gui-*-win64.zip)
+          echo ::set-output name=upload_win64::$(basename dist/streamlink-twitch-gui-*-win64.zip | sed 's/\.zip$//')
+          echo ::set-output name=archive_osx64::$(basename dist/streamlink-twitch-gui-*-macOS.tar.gz)
+          echo ::set-output name=upload_osx64::$(basename dist/streamlink-twitch-gui-*-macOS.tar.gz | sed 's/\.tar\.gz$//')
+          echo ::set-output name=archive_linux64::$(basename dist/streamlink-twitch-gui-*-linux64.tar.gz)
+          echo ::set-output name=upload_linux64::$(basename dist/streamlink-twitch-gui-*-linux64.tar.gz | sed 's/\.tar\.gz$//')
+      - name: Upload artifact (win64)
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: ${{ steps.names.outputs.archive_win64 }}
+          path: dist/${{ steps.names.outputs.archive_win64 }}
+      - name: Upload artifact (osx64)
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: ${{ steps.names.outputs.archive_osx64 }}
+          path: dist/${{ steps.names.outputs.archive_osx64 }}
+      - name: Upload artifact (linux64)
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: ${{ steps.names.outputs.archive_linux64 }}
+          path: dist/${{ steps.names.outputs.archive_linux64 }}
 
   release:
     name: New release

--- a/build/tasks/common/platforms.js
+++ b/build/tasks/common/platforms.js
@@ -60,5 +60,11 @@ module.exports = {
 		}
 
 		return Array.from( new Set( arr ) );
+	},
+
+	getDebugTargets( targets ) {
+		return targets.length && targets[ targets.length - 1 ] === "debug"
+			? [ true, targets.slice( 0, -1 ) ]
+			: [ false, targets.slice() ];
 	}
 };

--- a/build/tasks/configs/aliases.yml
+++ b/build/tasks/configs/aliases.yml
@@ -5,6 +5,10 @@ build:
 build:dev:
     - "clean:tmp_dev"
     - "webpack:dev"
+build:debug:
+    - "test"
+    - "clean:tmp_debug"
+    - "webpack:debug"
 build:prod:
     - "test"
     - "clean:tmp_prod"

--- a/build/tasks/configs/clean.js
+++ b/build/tasks/configs/clean.js
@@ -17,6 +17,10 @@ module.exports = {
 		"<%= dir.tmp_dev %>/**",
 		"!<%= dir.tmp_dev %>"
 	],
+	tmp_debug: [
+		"<%= dir.tmp_prod %>/**",
+		"!<%= dir.tmp_prod %>"
+	],
 	tmp_prod: [
 		"<%= dir.tmp_prod %>/**",
 		"!<%= dir.tmp_prod %>"

--- a/build/tasks/configs/run.js
+++ b/build/tasks/configs/run.js
@@ -10,5 +10,9 @@ module.exports = {
 
 	prod: {
 		src: "<%= dir.tmp_prod %>/**"
+	},
+
+	debug: {
+		src: "<%= dir.tmp_prod %>/**"
 	}
 };

--- a/build/tasks/custom/compile.js
+++ b/build/tasks/custom/compile.js
@@ -1,11 +1,12 @@
 module.exports = function( grunt ) {
 	const platforms = require( "../common/platforms" );
+	const { hasOwnProperty } = {};
 
 	function taskCompile() {
 		const options = this.options();
-		const { hasOwnProperty } = {};
+		const [ debug, targets ] = platforms.getDebugTargets( this.args );
 
-		for ( const platform of platforms.getPlatforms( ...this.args ) ) {
+		for ( const platform of platforms.getPlatforms( ...targets ) ) {
 			if ( !hasOwnProperty.call( options, platform ) ) {
 				throw new Error( `Missing compile option for platform: ${platform}` );
 			}
@@ -14,7 +15,7 @@ module.exports = function( grunt ) {
 				// run these tasks before the compilation
 				...( options[ platform ].before || [] ),
 				// the actual compile tasks
-				`nwjs:${platform}`,
+				`nwjs:${platform}${debug ? ":debug" : ""}`,
 				// run these tasks after the compilation
 				...( options[ platform ].after || [] )
 			]);

--- a/build/tasks/custom/dist.js
+++ b/build/tasks/custom/dist.js
@@ -31,12 +31,14 @@ module.exports = function( grunt ) {
 	function taskDist() {
 		const done = this.async();
 		const options = this.options();
-		const targets = getTargets( options, this.args );
+
+		const [ debug, args ] = platforms.getDebugTargets( this.args );
+		const targets = getTargets( options, args );
 
 		const tasks = unique([
 			// compile the application once for every given platform
 			...unique( targets.map( target => options[ target ].platform ) )
-				.map( platform => `compile:${platform}` ),
+				.map( platform => `compile:${platform}${debug ? ":debug" : ""}` ),
 			// run all dist tasks
 			...targets.map( target => options[ target ].tasks ).flat(),
 			// checksum

--- a/build/tasks/custom/nwjs.js
+++ b/build/tasks/custom/nwjs.js
@@ -5,6 +5,10 @@ module.exports = function( grunt ) {
 		const done = this.async();
 		const options = this.options();
 
+		if ( this.flags.debug ) {
+			options.flavor = "sdk";
+		}
+
 		const nw = new NwBuilder( options );
 
 		nw.on( "log", grunt.log.debug );

--- a/build/tasks/custom/release.js
+++ b/build/tasks/custom/release.js
@@ -2,12 +2,14 @@ module.exports = function( grunt ) {
 	const platforms = require( "../common/platforms" );
 
 	function taskRelease() {
+		const [ debug, targets ] = platforms.getDebugTargets( this.args );
+
 		grunt.task.run([
 			// build
-			"build:prod",
+			`build:${debug ? "debug" : "prod"}`,
 			// compile
-			...platforms.getPlatforms( ...this.args )
-				.map( platform => `compile:${platform}` )
+			...platforms.getPlatforms( ...targets )
+				.map( platform => `compile:${platform}${debug ? ":debug": ""}` )
 		]);
 	}
 

--- a/build/tasks/webpack/configurators/dev.js
+++ b/build/tasks/webpack/configurators/dev.js
@@ -24,12 +24,13 @@ module.exports = {
 	},
 
 	common( config, grunt, target ) {
-		const DEBUG = target === "dev";
-
-		// set DEBUG to true on each dev-target
 		config.plugins.push(
 			new webpack.DefinePlugin({
-				DEBUG
+				// debug build on top of NW.js SDK flavor
+				// with dev-tools, debug logging and initial warning message
+				DEBUG: target === "debug",
+				// same as debug build, but without initial warning message
+				DEVELOPMENT: target === "dev"
 			})
 		);
 	},

--- a/build/tasks/webpack/configurators/index.js
+++ b/build/tasks/webpack/configurators/index.js
@@ -9,5 +9,5 @@ module.exports = [
 	require( "./dev" ),
 	require( "./tests" ),
 	require( "./i18n" ),
-	require( "./prod" )
+	require( "./release" )
 ];

--- a/build/tasks/webpack/configurators/nwjs.js
+++ b/build/tasks/webpack/configurators/nwjs.js
@@ -1,5 +1,6 @@
 const { resolve: r } = require( "path" );
 const { pApp, pTest } = require( "../paths" );
+const { isTestTarget } = require( "../utils" );
 
 const webpack = require( "webpack" );
 const HtmlWebpackPlugin = require( "html-webpack-plugin" );
@@ -9,7 +10,17 @@ const HtmlWebpackPlugin = require( "html-webpack-plugin" );
  * Configurations for creating valid NW.js builds
  */
 module.exports = {
-	_nwjs( config, grunt, path, isProd = false ) {
+	common( config, grunt, target ) {
+		const path = isTestTarget( target )
+			? pTest
+			: pApp;
+		const isProd = target === "prod";
+
+		// split chunks
+		config.plugins.unshift(
+			new webpack.optimize.SplitChunksPlugin()
+		);
+
 		// NW.js package.json
 		config.module.rules.push({
 			type: "javascript/auto",
@@ -46,32 +57,5 @@ module.exports = {
 				template: r( path, "index.html" )
 			})
 		);
-	},
-
-	common( config ) {
-		// split chunks
-		config.plugins.unshift(
-			new webpack.optimize.SplitChunksPlugin()
-		);
-	},
-
-	dev( ...args ) {
-		this._nwjs( ...args, pApp );
-	},
-
-	prod( ...args ) {
-		this._nwjs( ...args, pApp, true );
-	},
-
-	test( ...args ) {
-		this._nwjs( ...args, pTest );
-	},
-
-	testdev( ...args ) {
-		this._nwjs( ...args, pTest );
-	},
-
-	coverage( ...args ) {
-		this._nwjs( ...args, pTest );
 	}
 };

--- a/build/tasks/webpack/configurators/release.js
+++ b/build/tasks/webpack/configurators/release.js
@@ -8,27 +8,34 @@ const WebpackSubresourceIntegrity = require( "webpack-subresource-integrity" );
 
 
 /**
- * Generic production build configurations
+ * Generic release build configurations
  */
 module.exports = {
-	prod( config, grunt ) {
+	_release( config, grunt, isProd ) {
 		// add license banners
 		const banner = [
 			grunt.config( "main.display-name" ),
 			`@version ${grunt.config( "version" )}`,
 			`@date ${new Date().toISOString()}`,
 			`@copyright ${grunt.config( "package.author" )}`,
-			`@license ${grunt.config( "package.license" )}`,
-			"",
-			"DO NOT MODIFY THIS FILE, OR THE APPLICATION WILL BREAK"
-		].join( "\n" );
+			`@license ${grunt.config( "package.license" )}`
+		];
+
+		if ( isProd ) {
+			banner.push(
+				"",
+				"DO NOT MODIFY THIS FILE, OR THE APPLICATION WILL BREAK"
+			);
+			config.plugins.push(
+				new WebpackSubresourceIntegrity({
+					hashFuncNames: [ "sha256" ]
+				})
+			);
+		}
 
 		config.plugins.push(
-			new WebpackSubresourceIntegrity({
-				hashFuncNames: [ "sha256" ]
-			}),
 			new webpack.BannerPlugin({
-				banner,
+				banner: banner.join( "\n" ),
 				entryOnly: true
 			})
 		);
@@ -39,5 +46,13 @@ module.exports = {
 				transformPath: targetPath => `${targetPath}.txt`
 			}])
 		);
+	},
+
+	debug( ...args ) {
+		return this._release( ...args, false );
+	},
+
+	prod( ...args ) {
+		return this._release( ...args, true );
 	}
 };

--- a/build/tasks/webpack/configurators/resolve.js
+++ b/build/tasks/webpack/configurators/resolve.js
@@ -1,36 +1,17 @@
 const { pApp, pTest } = require( "../paths" );
+const { isTestTarget } = require( "../utils" );
 
 
 /**
  * Resolver configurations for each build target
  */
 module.exports = {
-	_resolve( config, path ) {
+	common( config, grunt, target ) {
 		// set the first module resolve path
-		config.resolve.modules.unshift( path );
-	},
-
-	dev( config ) {
-		this._resolve( config, pApp );
-	},
-
-	prod( config ) {
-		this._resolve( config, pApp );
-	},
-
-	test( config ) {
-		this._resolve( config, pTest );
-	},
-
-	testdev( config ) {
-		this._resolve( config, pTest );
-	},
-
-	coverage( config ) {
-		this._resolve( config, pTest );
-	},
-
-	i18n( config ) {
-		this._resolve( config, pApp );
+		config.resolve.modules.unshift(
+			isTestTarget( target )
+				? pTest
+				: pApp
+		);
 	}
 };

--- a/build/tasks/webpack/targets/debug.js
+++ b/build/tasks/webpack/targets/debug.js
@@ -1,0 +1,7 @@
+module.exports = {
+	devtool: "inline-source-map",
+
+	output: {
+		path: "<%= dir.tmp_prod %>"
+	}
+};

--- a/build/tasks/webpack/targets/index.js
+++ b/build/tasks/webpack/targets/index.js
@@ -1,5 +1,6 @@
 module.exports = {
 	dev: require( "./dev" ),
+	debug: require( "./debug" ),
 	prod: require( "./prod" ),
 	test: require( "./test" ),
 	testdev: require( "./testdev" ),

--- a/build/tasks/webpack/utils.js
+++ b/build/tasks/webpack/utils.js
@@ -2,11 +2,16 @@ const { merge } = require( "lodash" );
 const globalBabelConfig = require( "./babel.config" );
 
 
+function isTestTarget( target ) {
+	return target === "test" || target === "testdev" || target === "coverage";
+}
+
 function buildBabelConfig( config ) {
 	return merge( {}, globalBabelConfig, config );
 }
 
 
 module.exports = {
+	isTestTarget,
 	buildBabelConfig
 };

--- a/src/app/data/models/versioncheck/model.js
+++ b/src/app/data/models/versioncheck/model.js
@@ -4,7 +4,8 @@ import Model from "ember-data/model";
 
 export default Model.extend({
 	version: attr( "string", { defaultValue: "" } ),
-	checkagain: attr( "number", { defaultValue: 0 } )
+	checkagain: attr( "number", { defaultValue: 0 } ),
+	showdebugmessage: attr( "number", { defaultValue: 0 } )
 
 }).reopenClass({
 	toString() { return "Versioncheck"; }

--- a/src/app/locales/en/modal.yml
+++ b/src/app/locales/en/modal.yml
@@ -13,6 +13,14 @@ confirm:
         apply: Apply
         discard: Discard
         cancel: Cancel
+debug:
+    header: "Debug build: {{version}}"
+    body: |
+        You are running a debug build of {{name}}.<br>
+        Please be careful with what you're doing and report any issues you may find.<br>
+        Thank you!
+    action:
+        close: Okay
 firstrun:
     header: "Thanks for using {{name}}!"
     body: Do you want to configure the application first before you start?

--- a/src/app/logger.js
+++ b/src/app/logger.js
@@ -1,4 +1,4 @@
-/* global DEBUG */
+/* global DEBUG, DEVELOPMENT */
 /* eslint-disable no-console */
 import Ember from "ember";
 import { argv } from "nwjs/argv";
@@ -9,7 +9,7 @@ const { logDebug, logError } = new Logger( "Application" );
 
 
 const onError = async ( type, err, debug ) => {
-	if ( DEBUG ) {
+	if ( DEVELOPMENT || DEBUG ) {
 		console.error( type, err, debug );
 	}
 	try {
@@ -23,9 +23,10 @@ window.addEventListener( "unhandledrejection", e => onError( e.type, e.reason, e
 window.addEventListener( "error", e => onError( "error", e.error ) );
 Ember.onerror = e => e && e.name !== "Adapter Error" ? onError( "Ember error", e ) : null;
 
-// don't log parameters when running a dev build via grunt
-if ( DEBUG ) {
+if ( DEVELOPMENT || DEBUG ) {
 	console.debug( argv );
-} else {
+}
+// don't log parameters when running a dev build via grunt
+if ( !DEVELOPMENT ) {
 	logDebug( "Parameters", argv );
 }

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,3 +1,4 @@
+/* global DEVELOPMENT */
 // special NW.js package.json import (see webpack config)
 import "./package.json";
 
@@ -8,8 +9,8 @@ global.process.on( "uncaughtException", function( err ) {
 	// do nothing if window was fully initialized
 	if ( window && window.initialized ) { return; }
 
-	// show the app window and dev tools while being in debug mode
-	if ( DEBUG ) {
+	// show the app window and dev tools while running in development mode
+	if ( DEVELOPMENT ) {
 		try {
 			let nwWindow = require( "nw.gui" ).Window.get();
 			nwWindow.show();

--- a/src/app/nwjs/debug.js
+++ b/src/app/nwjs/debug.js
@@ -1,2 +1,3 @@
-/* globals DEBUG */
-export const isDebug = DEBUG;
+/* globals DEBUG, DEVELOPMENT */
+export const isDebug = DEBUG || DEVELOPMENT;
+export const isDevelopment = DEVELOPMENT;

--- a/src/app/ui/components/modal/modal-debug/component.js
+++ b/src/app/ui/components/modal/modal-debug/component.js
@@ -1,0 +1,8 @@
+import ModalDialogComponent from "../modal-dialog/component";
+import layout from "./template.hbs";
+
+
+export default ModalDialogComponent.extend({
+	layout,
+	classNames: [ "modal-debug-component" ]
+});

--- a/src/app/ui/components/modal/modal-debug/template.hbs
+++ b/src/app/ui/components/modal/modal-debug/template.hbs
@@ -1,0 +1,17 @@
+<div>
+	{{#modal-header}}
+		{{t "modal.debug.header" version=modalContext.buildVersion}}
+	{{/modal-header}}
+	{{#modal-body}}
+		{{t "modal.debug.body" name=modalContext.displayName}}
+	{{/modal-body}}
+	{{#modal-footer classNames="button-list-horizontal"}}
+		{{#form-button
+			action=(action "close")
+			classNames="btn-primary"
+			icon="fa-arrow-left"
+		}}
+			{{t "modal.debug.action.close"}}
+		{{/form-button}}
+	{{/modal-footer}}
+</div>

--- a/src/config/update.json
+++ b/src/config/update.json
@@ -1,5 +1,6 @@
 {
 	"check-again": 604800000,
+	"show-debug-message": 86400000,
 	"githubreleases": {
 		"host": "https://api.github.com",
 		"namespace": "repos/streamlink/streamlink-twitch-gui"


### PR DESCRIPTION
Resolves #360 

- Renames the old `DEBUG` global var to `DEVELOPMENT`, adds the new `DEBUG` global var, and splits the logic between them accordingly.
- Implements the `build:debug` task alias, which runs tests and creates a debug build via `webpack:debug`.
- Refactors some webpack configs.
- Implements the `:debug` compile flag for the `nwjs`, `compile`, `release` and `dist` tasks.
  This flag has to be set at the end of the arguments of each task, eg. `dist:archive_win64:archive_osx64:archive_linux64:debug`.
  The debug flag gets passed through to the `nwjs` task, where it will use the NW.js SDK flavor instead of the normal flavor, so that the Chromium dev tools become available in the final debug build.
- Refactors the VersioncheckService.
- Adds a daily warning message when running a debug build.
- Adds scheduled CI runs each day at midnight and cancels the run if nothing new was committed since then.
  The final builds are uploaded as artifacts and can be downloaded from there (requires Github login).
  Unfortunately, due to a current restriction of the upload-artifacts action, all files are stored in a nested zip-archive / tarball. There's no workaround for that, as the upload-artifacts action always archives/compresses its inputs. Not building our own archives doesn't work either, as the action doesn't care for file permissions, which would break macOS/Linux builds. Also, our own archives are built deterministically, and this effort shouldn't be ignored or discarded.

TODO:
- Update the readme and wiki once merged and the first debug build has been uploaded.