### PR TITLE
build: restore old license txt extension

### DIFF
--- a/build/tasks/webpack/configurators/release.js
+++ b/build/tasks/webpack/configurators/release.js
@@ -44,7 +44,7 @@ module.exports = {
 			new CopyWebpackPlugin({
 				patterns: [{
 					from: r( pProjectRoot, "LICENSE" ),
-					transformPath: targetPath => `${targetPath}.txt`
+					to: "[name].txt"
 				}]
 			})
 		);


### PR DESCRIPTION
In commit 914620a2eaaee619e04cdcb69c84837f59f17814 copy-webpack-plugin
was upgraded from v6.0.3 to v9.0.0, skipping 2 major versions:

    -               "copy-webpack-plugin": "6.0.3",
    +               "copy-webpack-plugin": "9.0.0",

Unfortunately according to their release notes version 7.0.0 removed the
'transformPath' option used to rename the LICENSE file to LICENSE*.txt*.

This change migrates the build configuration over to using their
templating language instead.