### PR TITLE
build: add StartupWMClass to .desktop files

### DIFF
--- a/build/resources/appimage/build.sh
+++ b/build/resources/appimage/build.sh
@@ -104,6 +104,7 @@ GenericName=Twitch.tv browser for Streamlink
 Comment=Browse Twitch.tv and watch streams in your videoplayer of choice
 Keywords=streamlink;twitch;
 Categories=AudioVideo;Network;
+StartupWMClass=streamlink-twitch-gui
 Exec=${NAME}
 Icon=${NAME}
 EOF

--- a/build/resources/linux/add-menuitem.sh
+++ b/build/resources/linux/add-menuitem.sh
@@ -16,6 +16,7 @@ GenericName=Twitch.tv browser for Streamlink
 Comment=Browse Twitch.tv and watch streams in your videoplayer of choice
 Keywords=streamlink;twitch;
 Categories=AudioVideo;Network;
+StartupWMClass=streamlink-twitch-gui
 Exec=${HERE}/${APP}
 Icon=${APP}
 EOF


### PR DESCRIPTION
In some desktop environments, if someone pins the Appimage version to their panel or dock, they will get a duplicate icon whenever they launch it. 

This is because the launcher icon is associated only with the initial AppRun shell script. When the streamlink-twitch-gui binary is called, a second icon shows up on the user's task-switcher or dock.

Adding this line to the .desktop file prevents this.