### PR TITLE
chore: replace String.prototype.substr()

### DIFF
--- a/build/tasks/webpack/loaders/parse-json-loader.js
+++ b/build/tasks/webpack/loaders/parse-json-loader.js
@@ -24,7 +24,7 @@ module.exports = function( content ) {
 
 			if ( isString && value.startsWith( "~" ) ) {
 				const promise = new Promise( ( resolve, reject ) => {
-					this.loadModule( value.substr( 1 ), ( err, source, sourceMap, module ) => {
+					this.loadModule( value.slice( 1 ), ( err, source, sourceMap, module ) => {
 						if ( err ) {
 							return reject( err );
 						}

--- a/src/app/nwjs/argv.js
+++ b/src/app/nwjs/argv.js
@@ -73,9 +73,9 @@ const argTests = [
 	}, [] )
 ].map( name => name.length === 1
 	// shorthand parameters
-	? ( arg => arg.length > 1 && arg.substr( 1 ) === name )
+	? ( arg => arg.length > 1 && arg.slice( 1 ) === name )
 	// named parameters
-	: ( arg => arg.length > 2 && arg[1] === "-" && arg.substr( 2 ) === name )
+	: ( arg => arg.length > 2 && arg[1] === "-" && arg.slice( 2 ) === name )
 );
 
 
@@ -108,7 +108,7 @@ export function parseCommand( command ) {
 		const pos = command.indexOf( chromiumArgs );
 		/* istanbul ignore else */
 		if ( pos !== -1 ) {
-			command = command.substr( 0, pos ) + command.substr( pos + chromiumArgs.length );
+			command = command.slice( 0, pos ) + command.slice( pos + chromiumArgs.length );
 		}
 	}
 	// Remove user data dir parameter from the command line.

--- a/src/app/services/hotkey.js
+++ b/src/app/services/hotkey.js
@@ -103,8 +103,8 @@ function resolveHotkeyAlias( hotkeys ) {
 		aliases.push( hotkeys );
 
 		const sep = hotkeys.indexOf( "." );
-		const namespace = hotkeys.substr( 0, sep );
-		const action = hotkeys.substr( sep + 1 );
+		const namespace = hotkeys.substring( 0, sep );
+		const action = hotkeys.slice( sep + 1 );
 
 		if ( !hasOwnProperty.call( hotkeysConfig, namespace ) ) { return; }
 		const { actions } = hotkeysConfig[ namespace ];

--- a/src/app/ui/components/form/text-field/component.js
+++ b/src/app/ui/components/form/text-field/component.js
@@ -25,7 +25,7 @@ export default TextField.extend({
 				label: [ t`contextmenu.copy` ],
 				enabled: start !== end,
 				click() {
-					const selected = element.value.substr( start, end - start );
+					const selected = element.value.slice( start, end);
 					nwjs.clipboard.set( selected );
 				}
 			},
@@ -34,8 +34,8 @@ export default TextField.extend({
 				enabled: !element.readOnly && !element.disabled && clip && clip.length,
 				click() {
 					const value = element.value;
-					const before = value.substr( 0, element.selectionStart );
-					const after = value.substr( element.selectionEnd );
+					const before = value.slice( 0, element.selectionStart );
+					const after = value.slice( element.selectionEnd );
 
 					element.value = `${before}${clip}${after}`;
 					element.selectionStart = element.selectionEnd = before.length + clip.length;

--- a/src/app/utils/linkparser.js
+++ b/src/app/utils/linkparser.js
@@ -163,12 +163,12 @@ export function parseString( string ) {
 			// update the current text item:
 			// everything from the beginning to the match index (including the "lookbehind")
 			length = match.index + match[ 1 ].length;
-			texts[ i ] = current.substr( 0, length );
+			texts[ i ] = current.slice( 0, length );
 
 			// create a new text item after the current position:
 			// everything from the match ending (including the "lookahead") to the string end
 			length = match[ match.length - 1 ].length;
-			texts.splice( i + 1, 0, current.substr( re.lastIndex - length ) );
+			texts.splice( i + 1, 0, current.slice( re.lastIndex - length ) );
 
 			// insert the linkObj after the current position
 			links.splice( i, 0, linkObj );

--- a/src/app/utils/node/fs/download.js
+++ b/src/app/utils/node/fs/download.js
@@ -77,7 +77,7 @@ async function download( url, dest, time ) {
 	// download file path
 	const name = dest.name
 		|| basename( url.pathname )
-		|| `${String( Math.random() ).substr( 2 )}.download`;
+		|| `${String( Math.random() ).slice( 2 )}.download`;
 	const path = pathResolve( dest.dir, name );
 
 	// try to create download directory


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.