### PR TITLE
Add ad-free streaming for Turbo/subscribers via Twitch session token

### DIFF
--- a/build/tasks/webpack/configurators/app.js
+++ b/build/tasks/webpack/configurators/app.js
@@ -28,6 +28,7 @@ module.exports = {
 			test: /\.html$/,
 			exclude: [
 				resolve( pApp, "index.html" ),
+				resolve( pApp, "twitch-login.html" ),
 				resolve( pTest, "index.html" )
 			],
 			type: "asset/source"

--- a/build/tasks/webpack/configurators/nwjs.js
+++ b/build/tasks/webpack/configurators/nwjs.js
@@ -3,6 +3,7 @@ const { pApp, pTest } = require( "../paths" );
 const { isTestTarget } = require( "../utils" );
 
 const webpack = require( "webpack" );
+const CopyWebpackPlugin = require( "copy-webpack-plugin" );
 const HtmlWebpackPlugin = require( "html-webpack-plugin" );
 
 
@@ -51,5 +52,16 @@ module.exports = {
 				template: r( path, "index.html" )
 			})
 		);
+
+		if ( !isTestTarget( target ) ) {
+			config.plugins.push(
+				new CopyWebpackPlugin({
+					patterns: [{
+						from: r( pApp, "twitch-login.html" ),
+						to: "twitch-login.html"
+					}]
+				})
+			);
+		}
 	}
 };

--- a/src/app/data/models/settings/streaming/fragment.js
+++ b/src/app/data/models/settings/streaming/fragment.js
@@ -37,6 +37,7 @@ export default Fragment.extend({
 	stream_segment_threads: attr( "number", { defaultValue: 1, min: 1, max: 10 } ),
 	retry_open: attr( "number", { defaultValue: 1, min: 1, max: MAX } ),
 	retry_streams: attr( "number", { defaultValue: 1, min: 0, max: MAX } ),
+	twitch_oauth_token: attr( "string", { defaultValue: "" } ),
 
 	providerName: computed( "provider", function() {
 		const provider = get( this, "provider" );

--- a/src/app/data/models/stream/model.js
+++ b/src/app/data/models/stream/model.js
@@ -63,6 +63,10 @@ function settingsBool( attr ) {
 	});
 }
 
+function normalizeTwitchOAuthToken( token ) {
+	return String( token || "" ).trim().replace( /^oauth\s+/i, "" );
+}
+
 
 // TODO: refactor this module / export
 export {
@@ -176,6 +180,28 @@ export default Model.extend( /** @class Stream */ {
 		/** @this {Stream} */
 		function() {
 			return twitchStreamUrl.replace( "{channel}", this.stream.user_login );
+		}
+	),
+
+	hasTwitchToken: computed(
+		"settings.content.streaming.twitch_oauth_token",
+		/** @this {Stream} */
+		function() {
+			return !!normalizeTwitchOAuthToken(
+				this.settings.content.streaming.twitch_oauth_token
+			);
+		}
+	),
+
+	twitchApiHeaderValue: computed(
+		"settings.content.streaming.twitch_oauth_token",
+		/** @this {Stream} */
+		function() {
+			const token = normalizeTwitchOAuthToken(
+				this.settings.content.streaming.twitch_oauth_token
+			);
+
+			return token ? `Authorization=OAuth ${token}` : "";
 		}
 	)
 

--- a/src/app/data/models/twitch/subscription/adapter.js
+++ b/src/app/data/models/twitch/subscription/adapter.js
@@ -1,0 +1,22 @@
+import TwitchAdapter from "data/models/twitch/adapter";
+
+
+export default TwitchAdapter.extend({
+	/**
+	 * @param {DS.Store} store
+	 * @param {DS.Model} type
+	 * @param {Object} query
+	 * @return {Promise}
+	 */
+	async queryRecord( store, type, query ) {
+		const url = this._buildURL( type );
+		const data = await this.ajax( url, "GET", { data: query } );
+
+		/* istanbul ignore else */
+		if ( data !== null && Array.isArray( data[ "data" ] ) && data[ "data" ][ 0 ] ) {
+			data[ "data" ][ 0 ][ "_query" ] = query;
+		}
+
+		return data;
+	}
+});

--- a/src/app/data/models/twitch/subscription/model.js
+++ b/src/app/data/models/twitch/subscription/model.js
@@ -1,0 +1,21 @@
+import attr from "ember-data/attr";
+import Model from "ember-data/model";
+
+
+export default Model.extend( /** @class TwitchSubscription */ {
+	/** @type {string} */
+	broadcaster_id: attr( "string" ),
+	/** @type {string} */
+	broadcaster_login: attr( "string" ),
+	/** @type {string} */
+	broadcaster_name: attr( "string" ),
+	/** @type {string} */
+	user_id: attr( "string" ),
+	/** @type {boolean} */
+	is_gift: attr( "boolean" ),
+	/** @type {string} */
+	tier: attr( "string" )
+
+}).reopenClass({
+	toString() { return "helix/subscriptions/user"; }
+});

--- a/src/app/data/models/twitch/subscription/serializer.js
+++ b/src/app/data/models/twitch/subscription/serializer.js
@@ -1,0 +1,16 @@
+import TwitchSerializer from "data/models/twitch/serializer";
+
+
+export default TwitchSerializer.extend({
+	modelNameFromPayloadKey() {
+		return "twitch-subscription";
+	},
+
+	normalize( modelClass, resourceHash, prop ) {
+		const { user_id } = resourceHash._query;
+		resourceHash[ "user_id" ] = user_id;
+		resourceHash[ this.primaryKey ] = `${user_id}-${resourceHash.broadcaster_id}`;
+
+		return this._super( modelClass, resourceHash, prop );
+	}
+});

--- a/src/app/init/instance-initializers/nwjs/instance-initializer.js
+++ b/src/app/init/instance-initializers/nwjs/instance-initializer.js
@@ -12,6 +12,7 @@ import { isDarwin } from "utils/node/platform";
 
 
 const { logDebug, logError } = new Logger( "NWjs EmberJS initializer" );
+const TWITCH_LOGIN_WINDOW_ID = "twitch-login";
 
 
 export default {
@@ -103,7 +104,13 @@ export default {
 
 		// listen for the close event and show the dialog instead of strictly shutting down
 		nwWindow.on( "close", function() {
-			if ( location.pathname !== "/index.html" ) {
+			if ( !location.pathname.endsWith( "index.html" ) ) {
+				nwWindow.close( true );
+				return;
+			}
+
+			// Auxiliary windows (e.g. Twitch login popup) must not quit the application.
+			if ( nwWindow.id === TWITCH_LOGIN_WINDOW_ID ) {
 				nwWindow.close( true );
 				return;
 			}

--- a/src/app/locales/en/routes.yml
+++ b/src/app/locales/en/routes.yml
@@ -65,6 +65,10 @@ channel:
         vodcast:
             title: Vodcast
             data: Stream is a Vodcast
+        subscription:
+            title: Subscription
+            subscribed: "You are subscribed to this channel (Tier {tier})"
+            hint: Configure a Twitch session token in the streaming settings to remove ads while watching as a subscriber.
     teams:
         empty: The returned list of teams is empty.
     settings:

--- a/src/app/locales/en/settings.yml
+++ b/src/app/locales/en/settings.yml
@@ -119,6 +119,16 @@ streaming:
         title: Headless mode
         description: Run the web browser invisibly in headless mode.
         checkbox: Enable headless mode
+    twitch-oauth:
+        title: Ad-free streaming (Turbo / subscriber)
+        description: Provide your Twitch website session token so Streamlink can request ad-free streams when your account has Turbo or a channel subscription.
+        notes: This uses a different token than the application's Twitch login. Ads are only removed if your account is eligible. Embedded ads may still appear.
+        placeholder: Paste OAuth token or use Connect account
+        manual-hint: You can paste the token manually from your browser's developer tools (Network tab, gql.twitch.tv request, Authorization header) or use the button below.
+        connect: Connect Twitch account
+        success: Twitch session token saved successfully.
+        error: Failed to retrieve Twitch session token. Please try again or paste the token manually.
+        warning: Using your website session token in third-party applications may violate Twitch's terms of service. Use at your own risk. The token expires periodically and must be renewed.
     playerinput:
         title: Player input
         description: Defines the method of how the stream data is being fed into the player.

--- a/src/app/locales/pt-br/routes.yml
+++ b/src/app/locales/pt-br/routes.yml
@@ -64,6 +64,10 @@ channel:
         vodcast:
             title: Vodcast
             data: O Stream é um Vodcast
+        subscription:
+            title: Assinatura
+            subscribed: "Você é assinante deste canal (Tier {tier})"
+            hint: Configure o token de sessão da Twitch nas configurações de streaming para remover anúncios ao assistir como assinante.
     teams:
         empty: A lista de times está vazia.
     settings:

--- a/src/app/locales/pt-br/settings.yml
+++ b/src/app/locales/pt-br/settings.yml
@@ -108,6 +108,16 @@ streaming:
         parameters:
             title: Parâmetros personalizados
             placeholder: Adicionar parâmetros personalizados
+    twitch-oauth:
+        title: Transmissão sem anúncios (Turbo / assinante)
+        description: Informe o token de sessão do site da Twitch para o Streamlink solicitar transmissões sem anúncios quando sua conta tiver Turbo ou assinatura no canal.
+        notes: Este token é diferente do login da aplicação. Os anúncios só são removidos se sua conta for elegível. Anúncios incorporados ainda podem aparecer.
+        placeholder: Cole o token OAuth ou use Conectar conta
+        manual-hint: Você pode colar o token manualmente nas ferramentas de desenvolvedor do navegador (aba Network, requisição gql.twitch.tv, cabeçalho Authorization) ou usar o botão abaixo.
+        connect: Conectar conta Twitch
+        success: Token de sessão da Twitch salvo com sucesso.
+        error: Falha ao obter o token de sessão da Twitch. Tente novamente ou cole o token manualmente.
+        warning: Usar o token de sessão do site em aplicativos de terceiros pode violar os termos de serviço da Twitch. Use por sua conta e risco. O token expira periodicamente e precisa ser renovado.
     playerinput:
         title: Entrada de dados do tocador de vídeo
         description: Define o método de entrada de dados da transmissão no tocador de vídeo.

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -23,5 +23,23 @@
 		"256": "~assets/icons/icon-256.png"
 	},
 
-	"chromium-args": "--disable-devtools --enable-features=NativeNotifications --disable-smooth-scrolling --disable-features=nw2"
+	"chromium-args": "--disable-devtools --enable-features=NativeNotifications --disable-smooth-scrolling --disable-features=nw2 --enable-webview-tag",
+
+	"webview": {
+		"partitions": [
+			{
+				"name": "persist:twitchlogin",
+				"accessible_resources": [ "*://*.twitch.tv/*" ]
+			}
+		]
+	},
+
+	"permissions": [
+		"cookies",
+		"webview",
+		"*://*.twitch.tv/*"
+	],
+	"host_permissions": [
+		"*://*.twitch.tv/*"
+	]
 }

--- a/src/app/services/nwjs.js
+++ b/src/app/services/nwjs.js
@@ -1,8 +1,8 @@
 import { getOwner } from "@ember/application";
-import { get, computed } from "@ember/object";
+import { get, computed, set } from "@ember/object";
 import { default as Service, inject as service } from "@ember/service";
 import { quit } from "nwjs/App";
-import { Clipboard, Shell } from "nwjs/nwGui";
+import { Clipboard, Shell, Window } from "nwjs/nwGui";
 import {
 	default as nwWindow,
 	toggleVisibility,
@@ -19,6 +19,9 @@ import { ATTR_GUI_INTEGRATION_TRAY } from "data/models/settings/gui/fragment";
 const { hasOwnProperty } = {};
 const reVariable = /{(\w+)}/g;
 const modalCloseContext = {};
+const TWITCH_LOGIN_PAGE = "twitch-login.html";
+const TWITCH_LOGIN_WINDOW_ID = "twitch-login";
+const TWITCH_LOGIN_TOKEN_KEY = "twitch-oauth-token";
 
 
 export default Service.extend( /** @class NwjsService */ {
@@ -65,6 +68,151 @@ export default Service.extend( /** @class NwjsService */ {
 		});
 
 		Shell.openExternal( url );
+	},
+
+	/**
+	 * Open an embedded Twitch login window and read the website session token.
+	 * @returns {Promise<string>}
+	 */
+	openTwitchLogin() {
+		// The login window loads Twitch inside a <webview> (no Node context, so it
+		// won't crash) and writes the auth-token to localStorage, which is shared
+		// because both pages live under the same chrome-extension:// origin.
+		try {
+			window.localStorage.removeItem( TWITCH_LOGIN_TOKEN_KEY );
+		} catch ( e ) {
+			// ignore
+		}
+
+		return new Promise( ( resolve, reject ) => {
+			let settled = false;
+			let saving = false;
+			let pollInterval = null;
+			let loginWin = null;
+
+			const cleanup = () => {
+				if ( pollInterval ) {
+					clearInterval( pollInterval );
+					pollInterval = null;
+				}
+				if ( loginWin === this._twitchLoginWindow ) {
+					this._twitchLoginWindow = null;
+				}
+			};
+
+			const settle = ( fn, value ) => {
+				if ( settled ) {
+					return;
+				}
+				settled = true;
+				cleanup();
+				fn( value );
+			};
+
+			const closeLoginWindow = () => {
+				if ( !loginWin ) {
+					return;
+				}
+				try {
+					loginWin.close( true );
+				} catch ( e ) {
+					// ignore
+				}
+			};
+
+			const readStoredToken = () => {
+				let token = null;
+				try {
+					token = window.localStorage.getItem( TWITCH_LOGIN_TOKEN_KEY );
+				} catch ( e ) {
+					return false;
+				}
+				if ( !token ) {
+					return false;
+				}
+				try {
+					window.localStorage.removeItem( TWITCH_LOGIN_TOKEN_KEY );
+				} catch ( e ) {
+					// ignore
+				}
+				const value = String( token ).trim();
+				if ( !value || saving ) {
+					return false;
+				}
+				saving = true;
+				this._saveTwitchOAuthToken( value ).then(
+					() => {
+						closeLoginWindow();
+						settle( resolve, value );
+					},
+					err => {
+						closeLoginWindow();
+						settle( reject, err );
+					}
+				);
+				return true;
+			};
+
+			// Keep the main application window open while the login window is shown.
+			setVisibility( true );
+
+			Window.open( TWITCH_LOGIN_PAGE, {
+				id: TWITCH_LOGIN_WINDOW_ID,
+				width: 1000,
+				height: 760,
+				show: true,
+				focus: true,
+				resizable: true,
+				frame: true,
+				show_in_taskbar: true
+			}, win => {
+				if ( !win ) {
+					settle( reject, new Error( "Failed to open Twitch login window" ) );
+					return;
+				}
+
+				loginWin = win;
+				this._twitchLoginWindow = win;
+
+				// Closing the child window must never quit the whole application.
+				win.on( "close", function() {
+					try {
+						this.close( true );
+					} catch ( e ) {
+						// ignore
+					}
+				});
+
+				// After the window was closed, do a final read attempt
+				win.on( "closed", () => {
+					if ( !readStoredToken() && !saving ) {
+						settle( reject, new Error( "Twitch login window was closed" ) );
+					}
+				});
+
+				pollInterval = setInterval( readStoredToken, 1000 );
+				// immediate attempt (covers fast logins and tests)
+				readStoredToken();
+			});
+		})
+			.finally( () => {
+				setVisibility( true );
+				this.focus( true );
+			});
+	},
+
+	/**
+	 * @param {string} token
+	 * @returns {Promise}
+	 */
+	async _saveTwitchOAuthToken( token ) {
+		const settings = this.settings.content;
+		if ( !settings ) {
+			throw new Error( "Settings not loaded" );
+		}
+
+		set( settings, "streaming.twitch_oauth_token", token );
+		await settings.save();
 	},
 
 	minimize() {

--- a/src/app/services/streaming/provider/parameters.js
+++ b/src/app/services/streaming/provider/parameters.js
@@ -27,6 +27,11 @@ export const parameters = [
 		"stream.low_latency"
 	),
 	new Parameter(
+		"--twitch-api-header",
+		"stream.hasTwitchToken",
+		"stream.twitchApiHeaderValue"
+	),
+	new Parameter(
 		"--webbrowser",
 		null,
 		"stream.webbrowser"

--- a/src/app/twitch-login.html
+++ b/src/app/twitch-login.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf8">
+<title>Twitch Login</title>
+<style>
+	html, body {
+		margin: 0;
+		padding: 0;
+		width: 100%;
+		height: 100%;
+		overflow: hidden;
+		background: #0e0e10;
+	}
+	#status {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		padding: 6px 10px;
+		font: 12px sans-serif;
+		color: #efeff1;
+		background: #18181b;
+		z-index: 2;
+	}
+	webview {
+		position: absolute;
+		top: 28px;
+		left: 0;
+		width: 100%;
+		height: calc(100% - 28px);
+		border: 0;
+		display: block;
+	}
+</style>
+</head>
+<body>
+<div id="status">Carregando login da Twitch...</div>
+<webview
+	id="tw"
+	partition="persist:twitchlogin"
+></webview>
+<script>
+(function() {
+	var TOKEN_KEY = "twitch-oauth-token";
+	var TWITCH_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+		+ "AppleWebKit/537.36 (KHTML, like Gecko) "
+		+ "Chrome/120.0.0.0 Safari/537.36";
+	var gui = require( "nw.gui" );
+	var win = gui.Window.get();
+	var webview = document.getElementById( "tw" );
+	var status = document.getElementById( "status" );
+	var done = false;
+
+	// Use a clean desktop Chrome user-agent so Twitch doesn't reject the
+	// embedded browser and end up in a redirect loop.
+	try {
+		webview.setAttribute( "useragent", TWITCH_UA );
+	} catch ( e ) {}
+	try {
+		if ( webview.setUserAgentOverride ) {
+			webview.setUserAgentOverride( TWITCH_UA );
+		}
+	} catch ( e ) {}
+	webview.setAttribute( "src", "https://www.twitch.tv/login" );
+
+	// closing this child window must never quit the whole application
+	win.on( "close", function() {
+		this.close( true );
+	});
+
+	function setStatus( text ) {
+		if ( status ) { status.textContent = text; }
+	}
+
+	function finish( token ) {
+		if ( done ) { return; }
+		done = true;
+		try {
+			localStorage.setItem( TOKEN_KEY, token );
+		} catch ( e ) {}
+		setStatus( "Login detectado! Fechando..." );
+	}
+
+	function readToken() {
+		if ( done ) { return; }
+		if ( !window.chrome || !chrome.cookies ) { return; }
+
+		var storeId;
+		try {
+			storeId = webview.getCookieStoreId();
+		} catch ( e ) {
+			storeId = undefined;
+		}
+
+		var query = {
+			url: "https://www.twitch.tv/",
+			name: "auth-token"
+		};
+		if ( storeId !== undefined && storeId !== null ) {
+			query.storeId = String( storeId );
+		}
+
+		try {
+			chrome.cookies.get( query, function( cookie ) {
+				if ( chrome.runtime && chrome.runtime.lastError ) { return; }
+				if ( cookie && cookie.value ) {
+					finish( String( cookie.value ).trim() );
+				}
+			});
+		} catch ( e ) {}
+	}
+
+	webview.addEventListener( "loadcommit", function() {
+		setStatus( "Faça login na sua conta Twitch..." );
+		readToken();
+	});
+	webview.addEventListener( "contentload", readToken );
+	webview.addEventListener( "loadstop", readToken );
+
+	setInterval( readToken, 1000 );
+})();
+</script>
+</body>
+</html>

--- a/src/app/ui/routes/channel/index/route.js
+++ b/src/app/ui/routes/channel/index/route.js
@@ -1,13 +1,55 @@
 import { getOwner } from "@ember/application";
+import { set } from "@ember/object";
+import { inject as service } from "@ember/service";
+import { AdapterError } from "ember-data/adapters/errors";
 import UserIndexRoute from "ui/routes/user/index/route";
 
 
 export default UserIndexRoute.extend({
+	/** @type {DS.Store} */
+	store: service(),
+
 	async model() {
 		return this.modelFor( "channel" );
 	},
 
 	refresh() {
 		return getOwner( this ).lookup( "route:channel" ).refresh();
+	},
+
+	async setupController( controller, model ) {
+		this._super( controller, model );
+		await this._loadSubscription( controller, model );
+	},
+
+	/**
+	 * @param {Controller} controller
+	 * @param {Object} model
+	 * @returns {Promise}
+	 */
+	async _loadSubscription( controller, model ) {
+		set( controller, "isSubscribed", false );
+		set( controller, "subscriptionTier", null );
+
+		const { session } = this.auth;
+		if ( !session || !session.isLoggedIn ) {
+			return;
+		}
+
+		try {
+			const subscription = await this.store.queryRecord( "twitch-subscription", {
+				broadcaster_id: model.user.id,
+				user_id: session.user_id
+			});
+			set( controller, "isSubscribed", true );
+			set( controller, "subscriptionTier", subscription.tier );
+		} catch ( e ) {
+			if ( e instanceof AdapterError ) {
+				const status = e.errors && e.errors[ 0 ] && e.errors[ 0 ].status;
+				if ( status === 404 || status === "404" ) {
+					return;
+				}
+			}
+		}
 	}
 });

--- a/src/app/ui/routes/channel/index/template.hbs
+++ b/src/app/ui/routes/channel/index/template.hbs
@@ -32,6 +32,13 @@
 				<dt><i class="fa fa-recycle"></i>{{t "routes.channel.details.vodcast.title"}}</dt>
 				<dd>{{t "routes.channel.details.vodcast.data"}}</dd>
 			{{/if}}
+			{{#if isSubscribed}}
+				<dt><i class="fa fa-heart"></i>{{t "routes.channel.details.subscription.title"}}</dt>
+				<dd>
+					{{t "routes.channel.details.subscription.subscribed" tier=subscriptionTier}}
+					<p class="small text-muted">{{t "routes.channel.details.subscription.hint"}}</p>
+				</dd>
+			{{/if}}
 		</dl>
 		<div class="button-list-horizontal">
 			{{open-chat user=user}}

--- a/src/app/ui/routes/settings/streaming/controller.js
+++ b/src/app/ui/routes/settings/streaming/controller.js
@@ -1,6 +1,7 @@
 import Controller from "@ember/controller";
-import { get, computed } from "@ember/object";
+import { get, computed, set } from "@ember/object";
 import { equal } from "@ember/object/computed";
+import { inject as service } from "@ember/service";
 import { streaming as streamingConfig } from "config";
 import {
 	default as SettingsStreaming,
@@ -24,6 +25,11 @@ function settingsAttrMeta( attr, prop ) {
 
 
 export default Controller.extend({
+	/** @type {IntlService} */
+	intl: service(),
+	/** @type {NwjsService} */
+	nwjs: service(),
+
 	platform,
 	providers,
 	contentClientIntegrityDocs,
@@ -69,5 +75,39 @@ export default Controller.extend({
 
 	retryOpenDefault: settingsAttrMeta( "retry_open", "defaultValue" ),
 	retryOpenMin: settingsAttrMeta( "retry_open", "min" ),
-	retryOpenMax: settingsAttrMeta( "retry_open", "max" )
+	retryOpenMax: settingsAttrMeta( "retry_open", "max" ),
+
+	twitchOAuthPending: false,
+	twitchOAuthMessage: null,
+	twitchOAuthMessageClass: null,
+
+	actions: {
+		async connectTwitchAccount( success, failure ) {
+			set( this, "twitchOAuthPending", true );
+			set( this, "twitchOAuthMessage", null );
+			set( this, "twitchOAuthMessageClass", null );
+
+			try {
+				const token = await this.nwjs.openTwitchLogin();
+				set( this, "model.streaming.twitch_oauth_token", token );
+				set(
+					this,
+					"twitchOAuthMessage",
+					this.intl.t( "settings.streaming.twitch-oauth.success" ).toString()
+				);
+				set( this, "twitchOAuthMessageClass", "text-success" );
+				success();
+			} catch ( e ) {
+				set(
+					this,
+					"twitchOAuthMessage",
+					this.intl.t( "settings.streaming.twitch-oauth.error" ).toString()
+				);
+				set( this, "twitchOAuthMessageClass", "text-danger" );
+				failure();
+			} finally {
+				set( this, "twitchOAuthPending", false );
+			}
+		}
+	}
 });

--- a/src/test/tests/services/nwjs.js
+++ b/src/test/tests/services/nwjs.js
@@ -43,11 +43,19 @@ module( "services/nwjs", function( hooks ) {
 		});
 
 		this.openModalSpy = sinon.spy();
+		this.windowOpenStub = sinon.stub();
+		this.windowGetAllStub = sinon.stub();
+		this.windowGetStub = sinon.stub();
+		this.settingsSaveStub = sinon.stub().resolves();
 
 		this.guiSettings = {
 			integration: ATTR_GUI_INTEGRATION_BOTH,
 			minimizetotray: false,
 			closetotray: false
+		};
+
+		this.streamingSettings = {
+			twitch_oauth_token: ""
 		};
 
 		this.owner.register( "service:modal", Service.extend({
@@ -66,7 +74,9 @@ module( "services/nwjs", function( hooks ) {
 					get closetotray() {
 						return self.guiSettings.closetotray;
 					}
-				}
+				},
+				streaming: self.streamingSettings,
+				save: self.settingsSaveStub
 			}
 		}) );
 
@@ -84,6 +94,11 @@ module( "services/nwjs", function( hooks ) {
 				},
 				Shell: {
 					openExternal: this.openExternalSpy
+				},
+				Window: {
+					open: this.windowOpenStub,
+					get: this.windowGetStub,
+					getAll: this.windowGetAllStub
 				}
 			},
 			"nwjs/Window": {
@@ -291,6 +306,97 @@ module( "services/nwjs", function( hooks ) {
 		assert.ok(
 			this.openExternalSpy.calledOnceWithExactly( "https://foo.bar/foo/bar" ),
 			"Opens browser with substituted URL"
+		);
+	});
+
+
+	test( "OpenTwitchLogin reads the token from localStorage", async function( assert ) {
+		/** @this {TestContextServicesNwjs} */
+		/** @type {NwjsService} */
+		const NwjsService = this.owner.lookup( "service:nwjs" );
+
+		window.localStorage.removeItem( "twitch-oauth-token" );
+
+		const handlers = {};
+		const fakeWin = {
+			id: "twitch-login",
+			on: ( event, fn ) => { handlers[ event ] = fn; },
+			close: sinon.spy()
+		};
+		this.windowOpenStub.callsFake( ( url, opts, cb ) => {
+			assert.strictEqual(
+				url,
+				"twitch-login.html",
+				"Opens the local Twitch login page"
+			);
+			assert.strictEqual( opts.id, "twitch-login", "Uses the Twitch login window id" );
+			assert.strictEqual( opts.frame, true, "Opens the login window with a native frame" );
+			// simulate the webview page having stored the token
+			window.localStorage.setItem( "twitch-oauth-token", "abcdef0123456789" );
+			cb( fakeWin );
+		});
+
+		const token = await NwjsService.openTwitchLogin();
+
+		assert.strictEqual( token, "abcdef0123456789", "Resolves with the token value" );
+		assert.strictEqual(
+			this.streamingSettings.twitch_oauth_token,
+			"abcdef0123456789",
+			"Stores the token in the streaming settings"
+		);
+		assert.ok( this.settingsSaveStub.calledOnce, "Saves the settings" );
+		assert.ok(
+			fakeWin.close.calledWithExactly( true ),
+			"Closes the login window after success"
+		);
+		assert.strictEqual(
+			window.localStorage.getItem( "twitch-oauth-token" ),
+			null,
+			"Clears the token from localStorage"
+		);
+		assert.ok(
+			this.setVisibilitySpy.calledWith( true ),
+			"Keeps the main window visible"
+		);
+	});
+
+
+	test( "OpenTwitchLogin rejects when the window is closed", async function( assert ) {
+		/** @this {TestContextServicesNwjs} */
+		/** @type {NwjsService} */
+		const NwjsService = this.owner.lookup( "service:nwjs" );
+
+		window.localStorage.removeItem( "twitch-oauth-token" );
+
+		const handlers = {};
+		const closeSpy = sinon.spy();
+		const fakeWin = {
+			id: "twitch-login",
+			on: ( event, fn ) => { handlers[ event ] = fn; },
+			close: closeSpy
+		};
+		this.windowOpenStub.callsFake( ( url, opts, cb ) => cb( fakeWin ) );
+
+		const promise = NwjsService.openTwitchLogin();
+		// user closes the login window before logging in
+		handlers[ "close" ].call( fakeWin );
+		handlers[ "closed" ]();
+
+		let caught;
+		try {
+			await promise;
+		} catch ( e ) {
+			caught = e;
+		}
+
+		assert.ok( caught instanceof Error, "Rejects when the login window is closed" );
+		assert.ok(
+			caught && /closed/i.test( caught.message ),
+			"Rejection has the expected message"
+		);
+		assert.ok(
+			closeSpy.calledWithExactly( true ),
+			"Force-closes the child window so the app stays open"
 		);
 	});
 


### PR DESCRIPTION
## Goal

Allow users with **Twitch Turbo** or a **channel subscription** to watch streams **without ads** through Streamlink, by providing the Twitch website session token (`auth-token`) to the `--twitch-api-header` parameter. It also adds a **visual subscription indicator** on the channel page.

## Motivation / Reasoning

Streamlink can request ad-free streams when it receives a valid Twitch session token (via `Authorization=OAuth <token>`), as long as the account has Turbo or a subscription. Currently the app provides no way to supply this token. This change adds:

1. **Token input** (manual **or** automatic through an embedded login).
2. **Automatic forwarding** of the token to Streamlink.
3. A **subscription indicator** on the channel, hinting the user about ad removal.

> **Important note:** the website session token is different from the application's Twitch login token (Helix API). Using this token in third-party applications may violate Twitch's Terms of Service — an explicit warning is shown in the UI. The token expires periodically and must be renewed.

---

## Changes per file

### Phase 1 — Token and forwarding to Streamlink

#### `src/app/data/models/settings/streaming/fragment.js`
- New persisted attribute to store the Twitch session token:

```js
twitch_oauth_token: attr( "string", { defaultValue: "" } ),
```

#### `src/app/data/models/stream/model.js`
- Helper function to normalize the token (trims whitespace and strips an `oauth ` prefix):

```js
function normalizeTwitchOAuthToken( token ) {
    return String( token || "" ).trim().replace( /^oauth\s+/i, "" );
}
```

- Two new computed properties: `hasTwitchToken` (whether a token is configured) and `twitchApiHeaderValue` (builds the `Authorization=OAuth <token>` value for Streamlink).

#### `src/app/services/streaming/provider/parameters.js`
- New parameter passed to Streamlink, enabled only when a token is present:

```js
new Parameter(
    "--twitch-api-header",
    "stream.hasTwitchToken",
    "stream.twitchApiHeaderValue"
),
```

#### `src/app/ui/routes/settings/streaming/template.hbs`
- New section in **Settings → Streaming** containing: an `input type="password"` field to paste the token manually, a **Connect Twitch account** button (`connectTwitchAccount`), and success/error messages plus a warning about the Terms of Service.

#### `src/app/ui/routes/settings/streaming/controller.js`
- Injects the `intl` and `nwjs` services.
- UI state: `twitchOAuthPending`, `twitchOAuthMessage`, `twitchOAuthMessageClass`.
- `connectTwitchAccount` action that calls `nwjs.openTwitchLogin()`, stores the token on the model, and shows success/error feedback.

---

### Phase 2 — Embedded automatic login (NW.js)

#### `src/app/twitch-login.html` *(new file)*
- Local login page that loads Twitch inside a **`<webview>`** (no Node context, which avoids the V8 crash).
- Sets a **desktop Chrome user-agent** to avoid `ERR_TOO_MANY_REDIRECTS`.
- Reads the `auth-token` cookie via `chrome.cookies.get` using the webview's cookie store (`getCookieStoreId()`) and writes the token to `localStorage` (shared because both pages live under the same `chrome-extension://` origin).
- Registers a `close` handler that calls `this.close(true)` so it **never quits the app**.

#### `src/app/services/nwjs.js`
- New `openTwitchLogin()` method: opens the local `twitch-login.html` page in a window with id `twitch-login`, polls `localStorage` until the token is available, saves it to the settings, and closes the window. Closing the window without a token is treated as an error (rejection).
- New `_saveTwitchOAuthToken( token )` method that persists the token to the settings.
- Helper constants: `TWITCH_LOGIN_PAGE`, `TWITCH_LOGIN_WINDOW_ID`, `TWITCH_LOGIN_TOKEN_KEY`.

#### `src/app/init/instance-initializers/nwjs/instance-initializer.js`
- Adjusts the global NW.js `close` handler so the auxiliary login window (id `twitch-login`) only closes itself instead of shutting down the application:

```js
if ( nwWindow.id === TWITCH_LOGIN_WINDOW_ID ) {
    nwWindow.close( true );
    return;
}
```

- Pathname check changed to `endsWith("index.html")` (more robust), and adds the `TWITCH_LOGIN_WINDOW_ID` constant.

#### `src/app/package.json` (NW.js manifest)
- `--enable-webview-tag` added to `chromium-args`.
- New `webview.partitions` section with the persistent `persist:twitchlogin` partition and `accessible_resources` for `*://*.twitch.tv/*`.
- Added permissions: `cookies`, `webview`, and the host `*://*.twitch.tv/*` (both in `permissions` and `host_permissions`).

#### `build/tasks/webpack/configurators/nwjs.js`
- Copies `twitch-login.html` into the build (via `CopyWebpackPlugin`), except for test targets.

#### `build/tasks/webpack/configurators/app.js`
- `twitch-login.html` added to the `exclude` list of the `asset/source` rule, so it is copied as a real page (not inlined as a string).

---

### Phase 3 — Channel subscription indicator (Helix API)

#### `src/app/data/models/twitch/subscription/model.js` *(new file)*
- Ember Data model `twitch-subscription` mapping the `helix/subscriptions/user` endpoint (`broadcaster_id`, `broadcaster_login`, `broadcaster_name`, `user_id`, `is_gift`, `tier`).

#### `src/app/data/models/twitch/subscription/adapter.js` *(new file)*
- Adapter that runs `queryRecord` and attaches the `_query` object to the payload (needed to build the primary key in the serializer).

#### `src/app/data/models/twitch/subscription/serializer.js` *(new file)*
- Serializer that extracts `user_id` from `_query` and sets the composite primary key `${user_id}-${broadcaster_id}`.

#### `src/app/ui/routes/channel/index/route.js`
- `setupController` queries the `twitch-subscription` model (only when logged in), exposes `isSubscribed` and `subscriptionTier` to the controller, and silently handles `404` (not subscribed).

#### `src/app/ui/routes/channel/index/template.hbs`
- Conditional block that displays "You are subscribed to this channel (Tier X)" with a hint about configuring the token to remove ads.

---

### Translations

#### `src/app/locales/en/settings.yml` and `src/app/locales/pt-br/settings.yml`
- New keys under `settings.streaming.twitch-oauth`: `title`, `description`, `notes`, `placeholder`, `manual-hint`, `connect`, `success`, `error`, `warning`.

#### `src/app/locales/en/routes.yml` and `src/app/locales/pt-br/routes.yml`
- New keys under `routes.channel.details.subscription`: `title`, `subscribed`, `hint`.

---

### Tests

#### `src/test/tests/services/nwjs.js`
- Mocks for `Window.open` and the settings (`save`), plus a `streamingSettings` stub.
- Test **`OpenTwitchLogin reads the token from localStorage`** — verifies the token written by the login page is read, saved to the settings, and the window is closed.
- Test **`OpenTwitchLogin rejects when the window is closed`** — verifies that closing the window without a token rejects the Promise and that `close(true)` is called (so the app does not quit).

---

## Bugs fixed during development

| Problem | Cause | Fix |
|---|---|---|
| App closed when clicking "Connect Twitch account" | NW.js child window shut down the whole application on close | `close` handler with `this.close(true)` on the page plus guard in the initializer by window id |
| Fatal V8 crash (`Check failed: !holder_.is_null()`) | Loading `twitch.tv` in a window with injected Node (mixed-context) | Load Twitch inside an isolated `<webview>` |
| `Access to extension API denied` (cookies) | Missing host permissions and webview store | `host_permissions` + reading via `getCookieStoreId()` |
| `ERR_TOO_MANY_REDIRECTS` during login | Twitch rejected the embedded browser user-agent | Desktop Chrome user-agent on the `<webview>` |
| App wouldn't open after build | SRI hash mismatch in `index.html` | Full rebuild regenerating `index.html` |

## How to test

1. Open **Settings → Streaming**.
2. Click **Connect Twitch account** → opens the embedded login window.
3. Log in → the window closes by itself and the token is saved (or paste the token manually).
4. Open a stream → Streamlink receives `--twitch-api-header` automatically.
5. On a channel page where you are subscribed, check the subscription badge.

## Notes / Risks

- Using the website session token may violate Twitch's Terms of Service (warning shown in the UI). Embedded (server-side) ads may still appear.
- The subscription indicator is visual only; it does not remove ads by itself.
- Full test suite passing (including the new `openTwitchLogin` tests).

---

## List of changed files

**New files:**
- `src/app/twitch-login.html`
- `src/app/data/models/twitch/subscription/model.js`
- `src/app/data/models/twitch/subscription/adapter.js`
- `src/app/data/models/twitch/subscription/serializer.js`

**Modified files:**
- `build/tasks/webpack/configurators/app.js`
- `build/tasks/webpack/configurators/nwjs.js`
- `src/app/package.json`
- `src/app/data/models/settings/streaming/fragment.js`
- `src/app/data/models/stream/model.js`
- `src/app/init/instance-initializers/nwjs/instance-initializer.js`
- `src/app/locales/en/routes.yml`
- `src/app/locales/en/settings.yml`
- `src/app/locales/pt-br/routes.yml`
- `src/app/locales/pt-br/settings.yml`
- `src/app/services/nwjs.js`
- `src/app/services/streaming/provider/parameters.js`
- `src/app/ui/routes/channel/index/route.js`
- `src/app/ui/routes/channel/index/template.hbs`
- `src/app/ui/routes/settings/streaming/controller.js`
- `src/app/ui/routes/settings/streaming/template.hbs`
- `src/test/tests/services/nwjs.js`
