### PR TITLE
Quality: qualityIdToName uses array index check instead of quality id lookup, causing silent data corruption

### DIFF
--- a/src/app/init/initializers/localstorage/utils.js
+++ b/src/app/init/initializers/localstorage/utils.js
@@ -51,9 +51,7 @@ export function qualityIdToName( obj, qualities, key = "quality", setDefault = t
 	}
 
 	// unexpected value: set to the default value (the first defined quality)
-	if ( !hasOwnProperty.call( qualities, quality ) ) {
-		quality = 0;
-	}
+	quality = 0;
 
 	obj[ key ] = qualities[ quality ].id;
 }


### PR DESCRIPTION
## ✨ Code Quality

### Problem
In qualityIdToName, when a quality value is unexpected and not found via Array.find(), the fallback check `hasOwnProperty.call(qualities, quality)` tests whether `quality` is a valid ARRAY INDEX, not whether it's a valid quality id. If the unexpected quality value happens to be a valid array index (e.g., quality=3 in a 4+ element array), the function skips the default fallback and assigns the wrong quality from `qualities[quality].id`. This silently corrupts user channel settings during localstorage migration.


**Severity**: `medium`
**File**: `src/app/init/initializers/localstorage/utils.js`

### Solution
Replace the hasOwnProperty index check with a proper bounds check, or simply always reset to 0 when the find() fails:


### Changes
- `src/app/init/initializers/localstorage/utils.js` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1056